### PR TITLE
feat: remove default helper classes

### DIFF
--- a/src/components/Core/Core.tsx
+++ b/src/components/Core/Core.tsx
@@ -16,7 +16,7 @@ const Core = (props: CoreProps) => {
     const { profile, address } = props;
     return(
         <div className="Core">
-            <div className="Core-container centered-container">
+            <div className="Core-container container">
                 <div className="Core-infoSection">
                     <div className="Core-subSection mb-8">
                         <div className="Heading--sub mb-4 font-bold"> Information </div>

--- a/src/components/FeaturedProduct.tsx
+++ b/src/components/FeaturedProduct.tsx
@@ -20,7 +20,7 @@ const FeaturedProduct = (props: FeaturedProductProps) => {
   const { title, products } = props;
   return (
     <div className="FeaturedProduct">
-      <div className="centered-container">
+      <div className="container">
         <div className="FeaturedProduct-heading pb-2 m-4 Heading Heading--head">
           {title}
         </div>

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -18,7 +18,7 @@ type HeroProps = {
 const Hero = (props: HeroProps) => {
     return (
         <div className="Hero">
-            <div className="Hero-container centered-container">
+            <div className="Hero-container container">
                 <div className="Hero-content">  
                     <h1 className="Hero-title Heading Heading--sub">
                         {props.name}

--- a/src/components/Promo/Promo.tsx
+++ b/src/components/Promo/Promo.tsx
@@ -20,7 +20,7 @@ type PromoProps = {
 const Promo = (props: PromoProps) => {
   return (
     <div className="Promo">
-      <div className="centered-container flex flex-col md:flex-row">
+      <div className="container flex flex-col md:flex-row">
         {props.image && (
           <div className="w-full md:w-1/2">
             <Image className="Promo-image" imageField={props.image} />

--- a/src/components/Team/Team.tsx
+++ b/src/components/Team/Team.tsx
@@ -28,7 +28,7 @@ const Team = (props: TeamProps) => {
 
 
   return (
-    <div className="Team-container centered-container">
+    <div className="Team-container container">
       <h2 className="Team-title Heading--head">Meet Our Team</h2>
       <ul className="Team-list">
         {visible.map((member) => (

--- a/src/index.css
+++ b/src/index.css
@@ -7,19 +7,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-.centered-container {
-  @apply mx-auto px-5 md:px-14 max-w-screen-xl;
-}
-
-.section {
-  @apply mt-8 mb-16;
-}
-
-.primary-cta {
-  @apply bg-sky-500 hover:bg-sky-600;
-}
-
-.secondary-cta {
-  @apply bg-sky-700 hover:bg-sky-800;
-}


### PR DESCRIPTION
the centered-container isn't relevant because we've set the container.center
option to true in our tailwind config

we're using a different convention for our cta styling

TEST=manual