### PR TITLE
feat(i18n): add i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Making changes to this repo:
 
 `yext sites generate-test-data` - pull an example set of `localData` from your account
 
-`yext sites build` - Runs a production build against your `localData`
+`yext sites generate` - Runs a production build against your `localData`
 
 `yext sites serve` - Runs a local server against your production-built files
 
-- It's recommended to `yext sites build` followed by `yext sites serve` before committing in order to test that a real production build won't have any issues. In practice, development builds (via `npm run dev`) and production builds compile and bundle assets differently. For local development, ES Modules are loaded directly by the browser, allowing fast iteration during local development and also allows for hot module replacement (HMR). Other things like CSS are also loaded directly by the browser, including linking to sourcemaps. During a production build all of the different files are compiled (via ESBuild for jsx/tsx) and minified, creating assets as small as possible so that the final html files load quickly when served to a user.
+- It's recommended to `yext sites generate` followed by `yext sites serve` before committing in order to test that a real production build won't have any issues. In practice, development builds (via `npm run dev`) and production builds compile and bundle assets differently. For local development, ES Modules are loaded directly by the browser, allowing fast iteration during local development and also allows for hot module replacement (HMR). Other things like CSS are also loaded directly by the browser, including linking to sourcemaps. During a production build all of the different files are compiled (via ESBuild for jsx/tsx) and minified, creating assets as small as possible so that the final html files load quickly when served to a user.
 
 `npm run fmt` - Automatically formats all code
 
@@ -86,9 +86,9 @@ NOTE: You normally wouldn't want to check in the localData folder as it's only u
 
 ### sites-config
 
-Contains a single `ci.json` file. This file defines how the Yext CI system will build your project. It is not used during local dev. However, it is used when running a local production build (i.e. `yext sites build`).
+Contains a single `ci.json` file. This file defines how the Yext CI system will build your project. It is not used during local dev. However, it is used when running a local production build (i.e. `yext sites generate`).
 
-NOTE: A `features.json` file will automatically be generated during CI build for you based on the `config`s defined in your templates. One has been checked in to this repo so that `yext sites generate-test-data` works out of the box (assuming you've `yext init`'ed with your Yext account). If this file doesn't exist then `yext sites build` will implicitly generate a new one when it calls `npm run directbuild` (defined in `sites-config/ci.json`).
+NOTE: A `features.json` file will automatically be generated during CI build for you based on the `config`s defined in your templates. One has been checked in to this repo so that `yext sites generate-test-data` works out of the box (assuming you've `yext init`'ed with your Yext account). If this file doesn't exist then `yext sites generate` will implicitly generate a new one when it calls `npm run directbuild` (defined in `sites-config/ci.json`).
 
 ### src
 

--- a/i18n/en/translation.json
+++ b/i18n/en/translation.json
@@ -1,0 +1,3 @@
+{
+  "hello world": "EN__Hello World"
+}

--- a/i18n/smartling/api.js
+++ b/i18n/smartling/api.js
@@ -1,0 +1,50 @@
+import { DownloadFileParameters, FileType, RetrievalType, SmartlingApiClientBuilder, SmartlingFilesApi, UploadFileParameters } from "smartling-api-sdk-nodejs";
+
+class SmartlingAPI {
+  constructor(opts = {}) {
+    if (!opts.userID || !opts.userSecret || !opts.projectID) {
+      throw new Error('Error when initializing Smartling API, missing UserID, UserSecret, or ProjectID');
+    }
+
+    this.userID = opts.userID;
+    this.userSecret = opts.userSecret;
+    this.projectID = opts.projectID;
+
+    const apiBuilder = new SmartlingApiClientBuilder()
+    // .setLogger(console)
+    .setBaseSmartlingApiUrl('https://api.smartling.com')
+    .authWithUserIdAndUserSecret(this.userID, this.userSecret);
+
+    this.filesAPI = apiBuilder.build(SmartlingFilesApi);
+  }
+
+  async download(filename, locale) {
+    const downloadParams = new DownloadFileParameters()
+      .setRetrievalType(RetrievalType.PUBLISHED);
+
+    try {
+      return await this.filesAPI.downloadFile(this.projectID, filename, locale, downloadParams);
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  async upload(filename) {
+    const filepath = new URL(`./${filename}`, import.meta.url);
+    const uploadParams = new UploadFileParameters()
+      .setFileFromLocalFilePath(filepath)
+      .setFileType(FileType.GETTEXT)
+      .setFileUri(filename);
+    uploadParams.set('authorize', 'true');
+
+    try {
+      await this.filesAPI.uploadFile(this.projectID, uploadParams);
+    } catch (err) {
+      console.log(err);
+    }
+  }
+}
+
+export {
+  SmartlingAPI,
+}

--- a/i18n/smartling/index.js
+++ b/i18n/smartling/index.js
@@ -1,0 +1,124 @@
+import { i18nextToPo, gettextToI18next } from 'i18next-conv';
+import fs from 'fs';
+import { SmartlingAPI } from './api.js';
+import i18nConfig from './smartling.config.js';
+import { exec } from 'child_process';
+
+
+function relURL(path) {
+  return new URL(path, import.meta.url);
+}
+
+async function main() {
+  if (process.argv.length < 2) {
+    throw new Error('Invalid args - Usage: node index.js [pull|push]');
+  }
+  const commandName = process.argv[2];
+
+  const commands = {
+    'pull': pull,   // Push translations to smartling
+    'push': push,   // Pull translations from smartling
+    'scan': scan,   // Scan files for new translation strings to add to json files
+  };
+
+  // Check if command is valid
+  if (!commands.hasOwnProperty(commandName)) {
+    throw new Error('First arg invalid, must be a valid command: [pull|push]');
+  }
+
+  // Check if config is valid
+  //  NOOP if invalid config - that indicates this project is not using Smartling
+  if (!i18nConfig.userID || !i18nConfig.userSecret || !i18nConfig.projectID) {
+    console.log(`'smartling ${commandName}: NOOP - initialize smartling integration by filling out 'i18n/smartling/smartling.config.js'`);
+    return;
+  }
+
+  // Initialize the API
+  const api = new SmartlingAPI(i18nConfig);
+  await commands[commandName](api);
+}
+
+async function pull(api) {
+  // Check config.locales exists
+  if (i18nConfig.locales === undefined || i18nConfig.locales.length === 0) {
+    throw new Error('smartling pull: Error - must define locales in `i18n/smartling/smartling.config.js > locales`')
+  }
+
+  i18nConfig.locales.forEach(async locale => {
+    // Check if the yext/smartling locale name is different
+    let apiLocale = locale;
+    const localeMap = i18nConfig.smartlingLocaleToYextLocaleMapping;
+    if (localeMap !== null) {
+      Object.entries(localeMap).forEach(([smartlingLocale, yextLocaleList]) => {
+        if (yextLocaleList.includes(locale)) {
+          apiLocale = smartlingLocale;
+        }
+      });
+    }
+
+    // Download the translations & write to filesystem
+    const localeTranslations = await api.download('native.po', apiLocale);
+    const options = {
+      compatibilityJSON: 'v4',
+    };
+    gettextToI18next(apiLocale, localeTranslations, options).then(output => {
+      // Check directory exists before writing to it
+      const outDirPath = relURL(`../${locale}/`);
+      try {
+        fs.accessSync(outDirPath)
+      } catch (err) {
+        fs.mkdirSync(outDirPath, { recursive: true });
+      }
+      const outFilepath = new URL('translation.json', outDirPath);
+      console.log('Writing to ' + outFilepath);
+      fs.writeFileSync(outFilepath, output, {flag: 'w'});
+    });
+  });
+}
+
+async function push(api) {
+  // Read `config.defaultLocale` translations (fallback to 'en' if this field is empty)
+  let defaultSource = "{}";
+  let defaultLocale = i18nConfig.defaultLocale || 'en';
+  try {
+    defaultSource = fs.readFileSync(relURL(`../${defaultLocale}/translation.json`), 'utf-8');
+  } catch(err) {
+    console.log(`couldn\'t find "translation.json" source file for ${defaultLocale}`);
+  }
+
+  const source = {
+    ...JSON.parse(defaultSource),
+  }
+
+  // convert file to .po format && write to filesystem
+  // we need to convert JSON to .po because smartling doesn't support 
+  //  i18next JSON's plural format
+  const options = {
+    compatibilityJSON: 'v4',
+  };
+  i18nextToPo('en', JSON.stringify(source), options).then((output) => {
+    const outFilepath = relURL('./native.po');
+    fs.writeFileSync(outFilepath, output, {flag: 'w'});
+    console.log('Uploading native.po to smartling...');
+    api.upload('native.po');
+  });
+}
+
+async function scan() {
+  if (i18nConfig.locales === undefined || i18nConfig.locales.length === 0) {
+    throw new Error('smartling scan: Error - must define locales in `i18n/smartling/smartling.config.js > locales`')
+  }
+
+  const cmdString = `i18next 'src/**/*.{js,jsx,ts,tsx}' -c i18n/smartling/smartling.config.js`;
+  exec(cmdString, (error, stdout, stderr) => {
+    if (error) {
+      console.error(`exec error: ${error}`);
+      return;
+    }
+    console.log(`stdout: ${stdout}`);
+    console.error(`stderr: ${stderr}`);
+  });
+
+}
+
+await main();

--- a/i18n/smartling/index.js
+++ b/i18n/smartling/index.js
@@ -16,8 +16,8 @@ async function main() {
   const commandName = process.argv[2];
 
   const commands = {
-    'pull': pull,   // Push translations to smartling
-    'push': push,   // Pull translations from smartling
+    'pull': pull,   // Pull translations to smartling
+    'push': push,   // Push translations from smartling
     'scan': scan,   // Scan files for new translation strings to add to json files
   };
 

--- a/i18n/smartling/smartling.config.js
+++ b/i18n/smartling/smartling.config.js
@@ -1,0 +1,15 @@
+export default {
+  // Global Parameters
+  locales: ['en'],
+
+  // Smartling Parameters
+  userID: '',
+  userSecret: '',
+  projectID: '',
+  defaultLocale: '', // Defaults to 'en'
+  smartlingLocaleToYextLocaleMapping: {}, // ex. {"fr-FR": ["fr"]}
+
+  // i18next-parser Parameters for 'scan' script
+  createOldCatalogs: false,
+  output: 'i18n/$LOCALE/$NAMESPACE.json',
+}

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "dev": "pages dev",
     "features": "pages generate features",
-    "build": "vite build",
+    "build": "npm run i18npull && vite build",
     "fmt": "prettier -w .",
     "lint": "eslint .",
     "check-types": "tsc --noEmit --skipLibCheck --excludeFiles tailwind.config.cjs",
     "clean": "rm -rf .artifact-output .yext/ dist/ localData sites-rendered-output",
-    "generate": "plop"
+    "generate": "plop",
+    "i18npull": "node i18n/smartling/index.js pull",
+    "i18npush": "node i18n/smartling/index.js push",
+    "i18nscan": "node i18n/smartling/index.js scan"
   },
   "engines": {
     "node": ">=17"
@@ -26,12 +29,17 @@
     "@yext/types": "0.1.10-alpha",
     "classnames": "2.3.1",
     "libphonenumber-js": "1.10.14",
+    "i18next": "^21.9.1",
+    "i18next-conv": "^13.1.0",
+    "i18next-parser": "^6.5.0",
     "postcss-mixins": "^9.0.3",
     "pure-react-carousel": "1.29.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-i18next": "^11.18.5",
     "react-icons": "^4.4.0",
     "react-router-dom": "^6.3.0",
+    "smartling-api-sdk-nodejs": "^1.2.7",
     "typescript": "^4.6.2",
     "vite": "3.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-i18next": "^11.18.5",
     "react-icons": "^4.4.0",
     "react-router-dom": "^6.3.0",
-    "smartling-api-sdk-nodejs": "^1.2.7",
     "typescript": "^4.6.2",
     "vite": "3.0.3"
   },
@@ -59,6 +58,7 @@
     "postcss": "^8.4.12",
     "postcss-mixins": "^9.0.3",
     "prettier": "^2.6.2",
+    "smartling-api-sdk-nodejs": "^1.2.7",
     "tailwindcss": "^3.1.6"
   }
 }

--- a/src/common/i18n.tsx
+++ b/src/common/i18n.tsx
@@ -1,0 +1,40 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+const i18nDefaultOptions = {
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false
+  },
+  react: {
+    useSuspense: false,
+  },
+  debug: true,
+  saveMissing: true,
+}
+
+async function i18nInstanceBuilder(locale: string): Promise<typeof i18n | undefined> {
+  const json = await import(`../../i18n/${locale}/translation.json`);
+  const { default: translation } = json;
+
+  const i18nOptions = {
+    ...i18nDefaultOptions,
+    lng: locale,
+    resources: {
+      [locale]: {
+        translation,
+      }
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    i18n.use(initReactI18next).init(i18nOptions, (err, t) => {
+      if (err) return console.error(err);
+      resolve(i18n);
+    });
+  });
+}
+
+export {
+  i18nInstanceBuilder,
+};

--- a/src/common/i18n.tsx
+++ b/src/common/i18n.tsx
@@ -10,7 +10,6 @@ const i18nDefaultOptions = {
     useSuspense: false,
   },
   debug: true,
-  saveMissing: true,
 }
 
 async function i18nInstanceBuilder(locale: string): Promise<typeof i18n | undefined> {

--- a/src/layouts/main.tsx
+++ b/src/layouts/main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ConfigurationProvider } from '@yext/sites-react-components';
 import { TemplateDataProvider } from 'src/common/useTemplateData';
 import config from '../config';
@@ -6,36 +6,66 @@ import { Header } from 'src/components/common/Header';
 import type { TemplateRenderProps, BaseProfile } from 'src/types/entities';
 import Footer from 'src/components/common/Footer';
 
+import { I18nextProvider } from 'react-i18next';
+import { i18nInstanceBuilder } from "src/common/i18n";
+import i18n from 'i18next';
+
 interface MainProps {
   data: TemplateRenderProps<BaseProfile>;
   children?: React.ReactNode;
+  i18nCallback: Function;
 }
 
 const Main = (props: MainProps) => {
+  const [i18nInstance, setI18nInstance] = useState<typeof i18n | undefined>(undefined);
+  const document = props.data.document as BaseProfile;
   const {
-    _site
-  } = props.data.document;
+    _site,
+    locale,
+  } = document;
 
   const { children } = props;
 
+  useEffect(() => {
+    async function loadI18n(locale: string) {
+      const myI18nInstance = await i18nInstanceBuilder(locale);
+      if (myI18nInstance) { 
+        setI18nInstance(myI18nInstance);
+      }
+    }
+
+    loadI18n(locale);
+  }, []);
+
+  useEffect(() => {
+    if (i18nInstance) {
+      props.i18nCallback();
+    }
+  }, [i18nInstance]);
+
+
   return (
     <ConfigurationProvider value={config}>
-      <TemplateDataProvider value={props.data}>
-        <Header
-          logo={_site?.c_header?.logo}
-          links={_site?.c_header?.links || []}
-        />
-        {children}
-        <Footer
-          copyrightMessage={_site.c_copyrightMessage || ""}
-          facebook={_site.c_facebook}
-          instagram={_site.c_instagram}
-          youtube={_site.c_youtube}
-          twitter={_site.c_twitter}
-          linkedIn={_site.c_linkedIn}
-          footerLinks={_site.c_footerLinks || []}
-        />
-      </TemplateDataProvider>
+      {i18nInstance && (
+        <I18nextProvider i18n={i18nInstance}>
+          <TemplateDataProvider value={props.data}>
+          <Header
+            logo={_site?.c_header?.logo}
+            links={_site?.c_header?.links || []}
+          />
+          {children}
+          <Footer
+            copyrightMessage={_site.c_copyrightMessage || ""}
+            facebook={_site.c_facebook}
+            instagram={_site.c_instagram}
+            youtube={_site.c_youtube}
+            twitter={_site.c_twitter}
+            linkedIn={_site.c_linkedIn}
+            footerLinks={_site.c_footerLinks || []}
+          />
+          </TemplateDataProvider>
+        </I18nextProvider>
+      )}
     </ConfigurationProvider>
   )
 }

--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -8,7 +8,7 @@
  * template for every eligible entity in your Knowledge Graph.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import type {
   Template,
   GetPath,
@@ -37,6 +37,8 @@ import { Products, defaultFields as featuredProductFields } from "src/components
 import { Events, defaultFields as eventFields } from "src/components/entity/Events";
 import { Insights, defaultFields as InsightsFields } from 'src/components/entity/Insights';
 import { formatPhone } from 'src/common/helpers'
+
+import { Trans, useTranslation } from 'react-i18next'
 
 /**
  * Required when Knowledge Graph data is used for a template.
@@ -166,6 +168,7 @@ const Index: Template<TemplateRenderProps<LocationProfile>> = (data) => {
   const {
     id,
     geocodedCoordinate,
+    locale,
     name,
     address,
     description,
@@ -195,7 +198,7 @@ const Index: Template<TemplateRenderProps<LocationProfile>> = (data) => {
   const showInsights = insights?.title && insights?.insights
 
   return (
-    <Main data={data}>
+    <>
       {showBanner && <Banner text={banner.text} image={banner.image} />}
       <Hero name={name} cta1={hero?.cta1} cta2={hero?.cta2} address={address} background={hero?.background} hours={hours} numReviews={21} rating={4.5} />
       <Core profile={data.document} />
@@ -216,8 +219,20 @@ const Index: Template<TemplateRenderProps<LocationProfile>> = (data) => {
         id={id}
         relativePrefixToRoot={data.relativePrefixToRoot}
       />
+    </>
+  );
+};
+
+const IndexWrapper: Template<TemplateRenderProps> = (data) => {
+  const [translationsLoaded, setTranslationsLoaded] = useState(false);
+
+  return (
+    <Main data={data} i18nCallback={() => setTranslationsLoaded(true)}>
+      {translationsLoaded && (
+        <Index {...data} />
+      )}
     </Main>
   );
 };
 
-export default Index;
+export default IndexWrapper;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "baseUrl": "./",
     "target": "ESNext",
     "strict": true,
+    "module": "ESNext",
     "moduleResolution": "Node",
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
feat(i18n): add i18n
    
    - Translations are stored in `i18n/[locale]/translation.json`
    - locales must first be specified in `i18n/smartling/smartling.config.json`
    - Translation locale is determined by `data.document.locale` field from the Stream
    - Translations can be manually updated, OR
    - Translations can be push/pulled from smartling after adding auth info to `i18n/smartling/smartling.config.json`
    - Strings marked from translations but missing in translation.json files can be automatically added with `npm run i18nscan`.