### PR TITLE
feat(locator): add support for allResultsOnLoad Locator prop

### DIFF
--- a/src/components/search/Locator.tsx
+++ b/src/components/search/Locator.tsx
@@ -25,11 +25,13 @@ type LocatorProps = {
   placeholderText?: string;
   subTitle: string;
   title: string;
+  allResultsOnLoad?: boolean;
 };
 
 const Locator = (props: LocatorProps) => {
   const {
     displayAllOnNoResults = false,
+    allResultsOnLoad = false,
     placeholderText,
     subTitle,
     title,
@@ -41,6 +43,7 @@ const Locator = (props: LocatorProps) => {
   const searchActions = useSearchActions();
   const isLoading = useSearchState((state) => state.searchStatus.isLoading);
   const isDesktopBreakpoint = useBreakpoint("sm");
+  const [allLocationsLoaded, setAllLocationsLoaded] = useState(false);
   const [initialParamsLoaded, setInitialParamsLoaded] = useState(false);
   const initialParamsLoadedCallback = useCallback(
     () => setInitialParamsLoaded(true),
@@ -59,7 +62,13 @@ const Locator = (props: LocatorProps) => {
     setHoveredEntityId("");
   }, [searchActions.state.query.queryId]);
 
-  const results = useGetSearchResults<LocationProfile>(displayAllOnNoResults);
+  const results = useGetSearchResults<LocationProfile>(
+    displayAllOnNoResults,
+    allResultsOnLoad,
+    () => {
+      setAllLocationsLoaded(true);
+    }
+  );
 
   return (
     <LocatorProvider
@@ -74,7 +83,9 @@ const Locator = (props: LocatorProps) => {
       }}
     >
       <div className="Locator">
-        {(!initialParamsLoaded || isLoading) && <LoadingSpinner />}
+        {(!initialParamsLoaded ||
+          isLoading ||
+          (allResultsOnLoad && !allLocationsLoaded)) && <LoadingSpinner />}
         <div className="Locator-content">
           <SearchBox
             title={title}

--- a/src/components/search/utils/useGetSearchResults.ts
+++ b/src/components/search/utils/useGetSearchResults.ts
@@ -1,11 +1,74 @@
-import { Result, useSearchState } from "@yext/search-headless-react";
+import { useState, useEffect } from "react";
+import {
+  Result,
+  SearchCore,
+  useSearchState,
+  useSearchActions,
+} from "@yext/search-headless-react";
+
+async function fetchAll<T>(core: SearchCore, verticalKey: string) {
+  async function fetchPage(offset: number) {
+    const res = await core.verticalSearch({
+      query: "",
+      verticalKey: verticalKey,
+      limit: 50,
+      offset,
+      retrieveFacets: false,
+      skipSpellCheck: true,
+    });
+    return res;
+  }
+
+  let offset = 0;
+  let done = false;
+  const out = [];
+
+  while (!done) {
+    const res = await fetchPage(offset);
+    out.push(...(res.verticalResults.results as Result<T>[]));
+    if (out.length === res.verticalResults.resultsCount) {
+      done = true;
+    }
+    offset += 50;
+  }
+
+  return out;
+}
 
 // Get the results from the search state and cast to the given type.
-export function useGetSearchResults<T>(displayAllOnNoResults?: boolean) {
+export function useGetSearchResults<T>(
+  displayAllOnNoResults?: boolean,
+  allResultsOnLoad?: boolean,
+  allResultsLoadedCallback?: () => void
+) {
+  const [allResults, setAllResults] = useState<Result<T>[]>([]);
+  const [allResultsLoaded, setAllResultsLoaded] = useState(false);
+  const actions = useSearchActions();
+  const state = useSearchState((s) => s);
+  const initialLoad = !state.query.queryId;
+
+  useEffect(() => {
+    if (!allResultsOnLoad || allResultsLoaded || !state.vertical.verticalKey)
+      return;
+    async function load() {
+      // @ts-expect-error core is private, but we want to reuse the same core as the
+      // locator, rather than needing to create a new instance with the same configuration
+      // it's less convenient to use it indirectly through searchActions.executeVerticalQuery
+      // because that doesn't provide us direct access to results
+      const res = await fetchAll<T>(actions.core, state.vertical.verticalKey);
+      setAllResultsLoaded(true);
+      setAllResults(res);
+      if (allResultsLoadedCallback) allResultsLoadedCallback();
+    }
+    load();
+  }, []);
+
   const vertical = useSearchState((state) => state.vertical);
   const verticalResults = vertical.results;
   const allResultsForVertical =
     vertical?.noResults?.allResultsForVertical.results;
+
+  if (initialLoad && allResultsOnLoad) return allResults;
 
   const results = verticalResults?.length
     ? verticalResults


### PR DESCRIPTION
Things to be aware of:
* This shouldn't be used for accounts with lots of locations 
* The loading spinner we display as we load results blocks interaction with the searchbar, so you can't do anything until all results load. I'm not super familiar with how our old versions of this worked and whether that's fine. 
* Once you've done a search, there's no way to get back to the 'initial' screen. This is a side effect of the way the filtersearch component works, you have to select something from the dropdown and can't search for an empty string for example.