### PR TITLE
feat: use search entity slug for links to search page

### DIFF
--- a/sites-config/site-stream.json
+++ b/sites-config/site-stream.json
@@ -18,7 +18,8 @@
     "c_nearbySectionAPIKey",
     "c_searchExperienceAPIKey",
     "c_reviewsAPIKey",
-    "c_brand"
+    "c_brand",
+    "c_searchPage.slug"
   ],
   "localization": {
     "locales": ["en"],

--- a/src/components/directory/DirectoryHero.tsx
+++ b/src/components/directory/DirectoryHero.tsx
@@ -1,6 +1,6 @@
 import { useTemplateData } from "src/common/useTemplateData";
-import { SEARCH_PATH } from "src/config";
 import DirectorySearchBar from "src/components/directory/DirectorySearchBar";
+import { FALLBACK_SEARCH_PATH } from "src/config";
 
 interface DirectoryHeroProps {
   brand?: string;
@@ -9,7 +9,9 @@ interface DirectoryHeroProps {
 
 const DirectoryHero = (props: DirectoryHeroProps) => {
   const { brand, title } = props;
-  const { relativePrefixToRoot } = useTemplateData();
+  const { relativePrefixToRoot, document } = useTemplateData();
+  const search_path =
+    document?._site?.c_searchPage?.slug || FALLBACK_SEARCH_PATH;
 
   return (
     <div className="DirectoryHero bg-brand-gray-100 py-8 md:py-20 px-4 md:px-0">
@@ -19,7 +21,7 @@ const DirectoryHero = (props: DirectoryHeroProps) => {
       </h1>
       <DirectorySearchBar
         placeholder="Search by city and state or ZIP code"
-        searcherPath={relativePrefixToRoot + SEARCH_PATH}
+        searcherPath={relativePrefixToRoot + search_path}
       />
     </div>
   );

--- a/src/components/entity/Nearby.tsx
+++ b/src/components/entity/Nearby.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { Coordinate } from "@yext/types";
 import { Link } from "@yext/pages/components";
-import { SEARCH_PATH } from "src/config";
+import { FALLBACK_SEARCH_PATH } from "src/config";
 import { useTemplateData } from "src/common/useTemplateData";
 import type { LiveAPIProfile, LocationProfile } from "src/types/entities";
 import classNames from "classnames";
@@ -44,6 +44,8 @@ const Nearby = (props: NearbyProps) => {
   } = props;
 
   const { document, relativePrefixToRoot } = useTemplateData();
+  const search_path =
+    document?._site?.c_searchPage?.slug || FALLBACK_SEARCH_PATH;
   const apiKey = document._site.c_nearbySectionAPIKey;
 
   const [nearbyLocations, setNearbyLocations] = useState<
@@ -71,7 +73,7 @@ const Nearby = (props: NearbyProps) => {
   const renderLocatorLink = (cls?: string) => {
     return linkToLocator ? (
       <Link
-        href={buttonLink ?? relativePrefixToRoot + SEARCH_PATH}
+        href={buttonLink ?? relativePrefixToRoot + search_path}
         className={classNames("Button Button--primary mt-8 sm:mt-0", cls)}
       >
         {buttonText}

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export const MAPS_API_KEY = "<REPLACE-ME>";
 
 // Path for the search page.
 // Exported here since it's required across multiple pages such as the nearby section and directory search bar.
-export const SEARCH_PATH = "search";
+export const FALLBACK_SEARCH_PATH = "search";
 // Static filter field for FilterSearch.
 export const LOCATOR_STATIC_FILTER_FIELD = "builtin.location";
 // Entity type for FilterSearch

--- a/src/layouts/search.tsx
+++ b/src/layouts/search.tsx
@@ -30,9 +30,14 @@ const SearchLayout = ({ data }: SearchLayoutProps) => {
         {runtime.name === "browser" && (
           <BrowserRouter>
             <Locator
-              title={c_searchTitle}
-              subTitle={c_searchSubTitle}
-              placeholderText={c_searchPlaceholderText}
+              title={c_searchTitle || "Find a Location"}
+              subTitle={
+                c_searchSubTitle || "Search by city and state or ZIP code"
+              }
+              placeholderText={
+                c_searchPlaceholderText ||
+                "Search by city and state or ZIP code"
+              }
             />
           </BrowserRouter>
         )}

--- a/src/templates/search.tsx
+++ b/src/templates/search.tsx
@@ -2,14 +2,18 @@ import {
   Template,
   TemplateConfig,
   GetHeadConfig,
+  GetPath,
   HeadConfig,
 } from "@yext/pages";
 import "src/index.css";
 import { defaultHeadConfig } from "src/common/head";
 import { Main } from "src/layouts/main";
 import SearchLayout from "src/layouts/search";
-import { SearchPageProfile, TemplateRenderProps } from "src/types/entities";
-import { SEARCH_PATH } from "src/config";
+import {
+  SearchPageProfile,
+  TemplateRenderProps,
+  TemplateProps,
+} from "src/types/entities";
 
 /**
  * Not required depending on your use case.
@@ -24,6 +28,7 @@ export const config: TemplateConfig = {
       "uid",
       "meta",
       "name",
+      "slug",
       "c_searchTitle",
       "c_searchSubTitle",
       "c_searchPlaceholderText",
@@ -46,8 +51,8 @@ export const config: TemplateConfig = {
  * NOTE: This currently has no impact on the local dev path. Local dev urls currently
  * take on the form: featureName/entityId
  */
-export const getPath = (): string => {
-  return SEARCH_PATH;
+export const getPath: GetPath<TemplateProps<SearchPageProfile>> = (data) => {
+  return data.document.slug;
 };
 
 /**

--- a/src/types/entities.d.ts
+++ b/src/types/entities.d.ts
@@ -53,6 +53,9 @@ export interface SiteProfile extends BaseProfile {
   readonly c_nearbySectionAPIKey?: string;
   readonly c_searchExperienceAPIKey?: string;
   readonly c_reviewsAPIKey?: string;
+  readonly c_searchPage?: {
+    readonly slug?: string;
+  };
 }
 
 export interface ProductProfile extends BaseProfile {
@@ -63,9 +66,10 @@ export interface ProductProfile extends BaseProfile {
 }
 
 export interface SearchPageProfile extends BaseProfile {
-  c_searchTitle: string;
-  c_searchSubTitle: string;
-  c_searchPlaceholderText: string;
+  readonly slug: string;
+  readonly c_searchTitle?: string;
+  readonly c_searchSubTitle?: string;
+  readonly c_searchPlaceholderText?: string;
 }
 
 export interface EventDate {


### PR DESCRIPTION
the search page should be consistent with other pages where its url and links to it are fully
controlled by the slug field

J/T=none

TEST=manual