### PR TITLE
fix(): smartling.config language mapping example updated to use '-' i…

### DIFF
--- a/smartling.config.js
+++ b/smartling.config.js
@@ -13,7 +13,7 @@ const config = {
   defaultLocale: "en",
   smartlingLocaleToYextLocaleMapping: {
     // Mapping of Smartling locale code to Yext locale codes. Example:
-    // "zh-CN": ["zh_Hans"],
+    // "zh-CN": ["zh-Hans"],
   },
 };
 


### PR DESCRIPTION
…nstead of '_'

Since the current setup we have expects to have '-' instead of '_' in the directory name

cc @JRonkin 