### PR TITLE
fix: disable asset inlining

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
   },
   plugins: [react(), yextSSG()],
   build: {
+    assetsInlineLimit: 0, // TODO: Remove this if we ever upgrade to a Vite version that includes this fix: https://github.com/vitejs/vite/pull/14958
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
This is done because inlined icons don't work on Google search results. See this item:
https://yexttest.atlassian.net/browse/PC-231239

TEST=none
- Will amend once I test this