### PR TITLE
fix: prevent error about "(im)properly formatted default export"

### DIFF
--- a/functions/onUrlChange/urlWriteback.ts
+++ b/functions/onUrlChange/urlWriteback.ts
@@ -3,9 +3,11 @@ import { urlWritebackPlugin } from "https://deno.land/x/yextpages@plugins@1.0.0-
 const pageUrlCustomField = "c_pagesURL"; // Need to update to api name of CF storing prod URL for entities
 const API_KEY = "<REPLACE-ME>";
 
-export const main = urlWritebackPlugin({
+const main = urlWritebackPlugin({
   field: pageUrlCustomField,
   apiKey: API_KEY,
   environment: "prod",
   v: "20221010",
 });
+
+export default main;


### PR DESCRIPTION
this error was not actually preventing the function from working, but did make build logs confusing

J=none

TEST=manual