### PR TITLE
Updating dm_directoryParents field references and URLWriteback

### DIFF
--- a/src/common/head.tsx
+++ b/src/common/head.tsx
@@ -197,9 +197,9 @@ function metaDescription(data: TemplateRenderProps): string {
   if (entityMeta?.description) return entityMeta.description;
 
   // 2. Check for breadcrumbs
-  const { dm_directoryParents } = data.document;
-  if (dm_directoryParents) {
-    return `${dm_directoryParents
+  const { dm_directoryParents_defaultdirectory } = data.document;
+  if (dm_directoryParents_defaultdirectory) {
+    return `${dm_directoryParents_defaultdirectory
       .map((crumb: { name: string }) => crumb.name)
       .join(", ")}.`;
   }

--- a/src/common/schema.tsx
+++ b/src/common/schema.tsx
@@ -12,9 +12,9 @@ export function SchemaBuilder(
       }
     : null;
 
-  const breadcrumbs = data.document.dm_directoryParents
+  const breadcrumbs = data.document.dm_directoryParents_defaultdirectory
     ? (
-        data.document.dm_directoryParents as Array<{
+        data.document.dm_directoryParents_defaultdirectory as Array<{
           slug: string;
           name: string;
         }>

--- a/src/functions/onUrlChange/urlWriteback.ts
+++ b/src/functions/onUrlChange/urlWriteback.ts
@@ -1,9 +1,9 @@
-import { urlWritebackPlugin } from "https://deno.land/x/yextpages@plugins@1.0.0-beta.3/mod.ts";
+import { urlWriteback } from "@yext/pages/plugins";
 
 const pageUrlCustomField = "c_pagesURL"; // Need to update to api name of CF storing prod URL for entities
 const API_KEY = "<REPLACE-ME>";
 
-const main = urlWritebackPlugin({
+const main = urlWriteback({
   field: pageUrlCustomField,
   apiKey: API_KEY,
   environment: "prod",

--- a/src/layouts/city/configBuilder.tsx
+++ b/src/layouts/city/configBuilder.tsx
@@ -19,8 +19,8 @@ export const configBuilder: (
       "slug",
       "c_meta",
       // Directory Grid Fields
-      "dm_directoryParents.slug",
-      "dm_directoryParents.name",
+      "dm_directoryParents_defaultdirectory.slug",
+      "dm_directoryParents_defaultdirectory.name",
       "dm_directoryChildren.slug",
       "dm_directoryChildren.name",
       "dm_directoryChildren.address",

--- a/src/layouts/city/transformProps.tsx
+++ b/src/layouts/city/transformProps.tsx
@@ -12,9 +12,9 @@ import { getTranslations } from "src/i18n";
 export const transformProps: TransformProps<
   TemplateRenderProps<DirectoryProfile<never>>
 > = async (data) => {
-  const { dm_directoryParents, name } = data.document;
+  const { dm_directoryParents_defaultdirectory, name } = data.document;
 
-  (dm_directoryParents || []).push({ name: name, slug: "" });
+  (dm_directoryParents_defaultdirectory || []).push({ name: name, slug: "" });
 
   const translations = await getTranslations(data.document.locale);
 
@@ -22,7 +22,7 @@ export const transformProps: TransformProps<
     ...data,
     document: {
       ...data.document,
-      dm_directoryParents: dm_directoryParents,
+      dm_directoryParents_defaultdirectory: dm_directoryParents_defaultdirectory,
     },
     translations,
   });

--- a/src/layouts/directory.tsx
+++ b/src/layouts/directory.tsx
@@ -20,13 +20,13 @@ interface DirectoryGridLayoutProps {
 type DirectoryLayoutProps = DirectoryListLayoutProps | DirectoryGridLayoutProps;
 
 const DirectoryLayout = ({ data }: DirectoryLayoutProps) => {
-  const { dm_directoryParents, dm_directoryChildren } = data.document;
+  const { dm_directoryParents_defaultdirectory, dm_directoryChildren } = data.document;
 
   return (
     <>
       <DirectoryHero />
       <Breadcrumbs
-        breadcrumbs={dm_directoryParents || []}
+        breadcrumbs={dm_directoryParents_defaultdirectory || []}
         separator="/"
         className="container flex justify-center"
       />

--- a/src/layouts/entity/configBuilder.tsx
+++ b/src/layouts/entity/configBuilder.tsx
@@ -31,8 +31,8 @@ export const configBuilder: (
       "ref_listings.publisher",
       "additionalHoursText",
       "services",
-      "dm_directoryParents.name",
-      "dm_directoryParents.slug",
+      "dm_directoryParents_defaultdirectory.name",
+      "dm_directoryParents_defaultdirectory.slug",
       "dm_baseEntityCount",
       "slug",
       // About Fields

--- a/src/layouts/entity/template.tsx
+++ b/src/layouts/entity/template.tsx
@@ -34,7 +34,7 @@ interface EntityLayoutProps {
 }
 
 const EntityLayout = ({ data }: EntityLayoutProps) => {
-  const { dm_directoryParents: directoryParents } = data.document;
+  const { dm_directoryParents_defaultdirectory: directoryParents } = data.document;
 
   return (
     <>

--- a/src/layouts/entity/transformProps.tsx
+++ b/src/layouts/entity/transformProps.tsx
@@ -23,11 +23,11 @@ export const transformProps: TransformProps<
     localPhone,
     alternatePhone,
     address,
-    dm_directoryParents,
+    dm_directoryParents_defaultdirectory,
     name,
   } = data.document;
 
-  (dm_directoryParents || []).push({ name: name, slug: "" });
+  (dm_directoryParents_defaultdirectory || []).push({ name: name, slug: "" });
 
   const translations = await getTranslations(data.document.locale);
 
@@ -48,7 +48,7 @@ export const transformProps: TransformProps<
       ttyPhone: formatPhone(ttyPhone, address.countryCode),
       localPhone: formatPhone(localPhone, address.countryCode),
       alternatePhone: formatPhone(alternatePhone, address.countryCode),
-      dm_directoryParents: dm_directoryParents,
+      dm_directoryParents_defaultdirectory: dm_directoryParents_defaultdirectory,
     },
     translations,
   };

--- a/src/layouts/region/configBuilder.tsx
+++ b/src/layouts/region/configBuilder.tsx
@@ -19,8 +19,8 @@ export const configBuilder: (
       "slug",
       "c_meta",
       // Directory List Fields
-      "dm_directoryParents.slug",
-      "dm_directoryParents.name",
+      "dm_directoryParents_defaultdirectory.slug",
+      "dm_directoryParents_defaultdirectory.name",
       "dm_directoryChildren.slug",
       "dm_directoryChildren.name",
       "dm_directoryChildren.dm_baseEntityCount",

--- a/src/layouts/region/transformProps.tsx
+++ b/src/layouts/region/transformProps.tsx
@@ -12,9 +12,9 @@ import { getTranslations } from "src/i18n";
 export const transformProps: TransformProps<
   TemplateRenderProps<DirectoryProfile<never>>
 > = async (data) => {
-  const { dm_directoryParents, name } = data.document;
+  const { dm_directoryParents_defaultdirectory, name } = data.document;
 
-  (dm_directoryParents || []).push({ name: name, slug: "" });
+  (dm_directoryParents_defaultdirectory || []).push({ name: name, slug: "" });
 
   const translations = await getTranslations(data.document.locale);
 
@@ -22,7 +22,7 @@ export const transformProps: TransformProps<
     ...data,
     document: {
       ...data.document,
-      dm_directoryParents: dm_directoryParents,
+      dm_directoryParents_defaultdirectory: dm_directoryParents_defaultdirectory,
     },
     translations,
   };

--- a/src/layouts/root/configBuilder.tsx
+++ b/src/layouts/root/configBuilder.tsx
@@ -19,8 +19,8 @@ export const configBuilder: (
       "slug",
       "c_meta",
       // Directory List Fields
-      "dm_directoryParents.slug",
-      "dm_directoryParents.name",
+      "dm_directoryParents_defaultdirectory.slug",
+      "dm_directoryParents_defaultdirectory.name",
       "dm_directoryChildren.slug",
       "dm_directoryChildren.name",
       "dm_directoryChildren.dm_baseEntityCount",

--- a/src/layouts/root/transformProps.tsx
+++ b/src/layouts/root/transformProps.tsx
@@ -20,7 +20,7 @@ export const transformProps: TransformProps<
     ...data,
     document: {
       ...data.document,
-      dm_directoryParents: [{ name: name, slug: "" }],
+      dm_directoryParents_defaultdirectory: [{ name: name, slug: "" }],
     },
     translations,
   };

--- a/src/types/entities.d.ts
+++ b/src/types/entities.d.ts
@@ -193,14 +193,14 @@ export interface LocationProfile extends BaseProfile {
     readonly title?: string;
     readonly reviews?: ReviewProfile[];
   };
-  readonly dm_directoryParents?: Array<{ slug: string; name: string }>;
+  readonly dm_directoryParents_defaultdirectory?: Array<{ slug: string; name: string }>;
 }
 
 export type DirectoryProfile<T> = BaseProfile & {
   readonly name: string;
   readonly dm_baseEntityCount: number;
   readonly dm_directoryChildren?: T[];
-  readonly dm_directoryParents?: Array<{ slug: string; name: string }>;
+  readonly dm_directoryParents_defaultdirectory?: Array<{ slug: string; name: string }>;
   readonly slug: string;
 };
 


### PR DESCRIPTION
Pull request for the following updates:
1. Updating all `dm_directoryParents` field references in the Consulting Starter to `dm_directoryParents_defaultdirectory` in consideration of changes made to support overlapping DMs. Reference documentation [here](https://hitchhikers.yext.com/docs/pages/directory-management/?target=directory-manager-execution-process). The `dm_directoryParents` field now has a `dm_directoryManagerId` appended to disambiguate the parents field, in case there are multiple active directories.
2. Updating the URLWriteback function to use the Node version after upgrading to PagesJS 1.0.0. Relevant Slack thread [here](https://yextops.slack.com/archives/C02UVSE7P6W/p1707405328972519). 