### PR TITLE
fix: resolve JSON-LD schema crash and filter undefined graph nodes

### DIFF
--- a/src/common/schema.tsx
+++ b/src/common/schema.tsx
@@ -1,6 +1,8 @@
 import { SchemaWrapper, LocalBusiness, FAQPage } from "@yext/pages-components";
 import type { TemplateRenderProps } from "src/types/entities";
 
+const SCHEMA_CONTEXT = "https://schema.org";
+
 export function SchemaBuilder(
   data: TemplateRenderProps<Record<string, any>>
 ): string {
@@ -34,15 +36,15 @@ export function SchemaBuilder(
     : null;
 
   const json = {
+    "@context": SCHEMA_CONTEXT,
     "@graph": [
-      localBusiness && localBusiness,
-      faqs && faqs,
+      localBusiness,
+      faqs,
       breadcrumbs && {
-        "@context": "http://www.schema.org",
         "@type": "BreadcrumbList",
         itemListElement: breadcrumbs,
       },
-    ],
+    ].filter(Boolean),
   };
 
   return SchemaWrapper(json);


### PR DESCRIPTION
This was to resolve Sentry errors coming in saying @context was undefined for our pages schema

J=CR-4091